### PR TITLE
Adding DocuSealSubmitterEntityModel which should be used for embeddin…

### DIFF
--- a/Sources/DocuSealKit/Models/DocuSealEntityModel.swift
+++ b/Sources/DocuSealKit/Models/DocuSealEntityModel.swift
@@ -1,0 +1,20 @@
+//
+//  DocuSealEntityModel.swift
+//  docuseal-kit
+//
+//  Created by Stevenson Michel on 5/9/25.
+//
+
+/// Entity that can be used as signers, submitters e.t.c for embeding UI
+/// The token response should be { "token": "JWT", submitters: [DocuSealSubmitterEntityModel] }
+/// It'll prefill signers automatically
+public struct DocuSealSubmitterEntityModel: Codable, Sendable {
+    /// Person or Organization name
+    public var name: String
+    /// Role of the entity e.g Vender, Customer, Employee e.t.c
+    public var role: String
+    /// Email of the entity
+    public var email: String?
+    /// Phone number of the enity
+    public var phone: String?
+}


### PR DESCRIPTION
…g along side token

* Add DocuSealSubmitterEntityModel to be used when embedding It's useful for when embedding  the docuseal UI of which automatically have a drop down for signers