### PR TITLE
Make role, name, and folderName optional in models

### DIFF
--- a/Sources/DocuSealKit/Models/DocuSealEntityModel.swift
+++ b/Sources/DocuSealKit/Models/DocuSealEntityModel.swift
@@ -12,7 +12,7 @@ public struct DocuSealSubmitterEntityModel: Codable, Sendable {
     /// Person or Organization name
     public var name: String
     /// Role of the entity e.g Vender, Customer, Employee e.t.c
-    public var role: String
+    public var role: String?
     /// Email of the entity
     public var email: String?
     /// Phone number of the enity
@@ -27,7 +27,7 @@ public struct DocuSealSubmitterEntityModel: Codable, Sendable {
     /// Init
     public init(
         name: String,
-        role: String,
+        role: String? = nil,
         email: String? = nil,
         phone: String? = nil,
         metadata: [String: String]? = nil,

--- a/Sources/DocuSealKit/Models/DocuSealTokenRequest.swift
+++ b/Sources/DocuSealKit/Models/DocuSealTokenRequest.swift
@@ -15,7 +15,7 @@ public struct DocuSealTokenRequest: JWTPayload {
     let intergrationEmail: String
 
     /// New template name when creating a template with document_urls specified.
-    let name: String
+    let name: String?
 
     /// An array with public and downloadable document URLs to be opened in the form builder.
     /// Pass empty array to allow users to upload their files.
@@ -29,7 +29,7 @@ public struct DocuSealTokenRequest: JWTPayload {
     var templateID: Int?
 
     /// The folder name in which the template should be created.
-    var folderName: String
+    var folderName: String?
 
     /// Pass `false` to disable automatic PDF form fields extraction.
     /// PDF fields are automatically added by default.
@@ -49,10 +49,10 @@ public struct DocuSealTokenRequest: JWTPayload {
         externalID: String,
         userEmail: String,
         intergrationEmail: String,
-        templateName: String,
-        documentURLs: [String],
+        templateName: String? = nil,
+        documentURLs: [String] = [],
         templateID: Int? = nil,
-        folderName: String = "",
+        folderName: String? = nil,
         extractFields: Bool? = nil
     ) {
         self.externalID = externalID


### PR DESCRIPTION
Updated DocuSealSubmitterEntityModel and DocuSealTokenRequest to make 'role', 'name', and 'folderName' properties optional. This change improves flexibility when initializing these models without requiring these fields.