### PR TITLE
Add webhook key-value authentication and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,19 +224,18 @@ DocuSeal Kit supports three types of webhook events with full type safety:
 - `template.created` - New template was created
 - `template.updated` - Template was updated
 
-#### Webhook Signature Verification
+#### Webhook Authentication
+
+DocuSeal uses key-value pairs in request headers for webhook authentication. Configure this in DocuSeal Console > Webhooks > Add Secret.
 
 ```swift
-// Verify webhook signature for security
-let isValid = DocusealWebhookHandler.verifySignature(
-    requestBody: requestBody,
-    signatureHeader: "signature_from_header",
-    webhookSecret: "your_webhook_secret"
+// Verify webhook authenticity - throws DocuSealError.webhookAuthenticationError if invalid
+try DocusealWebhookHandler.verifyWebhookSecret(
+    receivedKey: request.headers["X-Secret-Key"]?.first ?? "",
+    receivedValue: request.headers["X-Secret-Value"]?.first ?? "",
+    expectedKey: "your-secret-key",
+    expectedValue: "your-secret-value"
 )
-
-guard isValid else {
-    throw YourError.invalidWebhookSignature
-}
 ```
 
 #### Type-Safe Event Processing

--- a/Sources/DocuSealKit/DocuSealError.swift
+++ b/Sources/DocuSealKit/DocuSealError.swift
@@ -12,6 +12,7 @@ public enum DocuSealError: Error {
     case decodingError(message: String)
     case encodingError(message: String)
     case invalidURL(url: String)
+    case webhookAuthenticationError(message: String)
 }
 
 extension DocuSealError: CustomStringConvertible {
@@ -25,6 +26,8 @@ extension DocuSealError: CustomStringConvertible {
             return "Encoding error: \(error)"
         case .invalidURL(let url):
             return "Invalid URL: \(url)"
+        case .webhookAuthenticationError(let message):
+            return "Webhook authentication error: \(message)"
         }
     }
 }

--- a/Sources/DocuSealKit/DocuSealWebhooks.swift
+++ b/Sources/DocuSealKit/DocuSealWebhooks.swift
@@ -524,24 +524,22 @@ public typealias DocuSealTemplateWebhookEvent = DocuSealWebhookEvent<DocuSealTem
 // MARK: - Webhook Handler
 
 public struct DocusealWebhookHandler {
-    /// Verify if the webhook request signature is valid (verify that the request came from DocuSeal)
-    public static func verifySignature(
-        requestBody: ByteBuffer,
-        signatureHeader: String,
-        webhookSecret: String
-    ) -> Bool {
-        // DocuSeal doesn't currently provide a specific signature verification mechanism
-        // This method is prepared for future implementation
-        // For now, return true but can be enhanced when DocuSeal adds signature verification
-        true
-    }
-
-    /// Verify if the webhook request credentials are valid (verify that the request came from DocuSeal)
-    public static func verifyCredentials(
-        key: String,
-        value: String
-    ) -> Bool {
-        key == value
+    /// Verify if the webhook request is valid using DocuSeal's key-value authentication
+    /// DocuSeal sends webhook secrets as key-value pairs in request headers
+    /// Configure this in DocuSeal Console > Webhooks > Add Secret
+    /// Throws DocuSealError.webhookAuthenticationError if verification fails
+    public static func verifyWebhookSecret(
+        receivedKey: String,
+        receivedValue: String,
+        expectedKey: String,
+        expectedValue: String
+    ) throws {
+        guard receivedKey == expectedKey && receivedValue == expectedValue else {
+            throw DocuSealError.webhookAuthenticationError(
+                message:
+                    "Invalid webhook credentials - received key '\(receivedKey)' with value '\(receivedValue)' does not match expected credentials"
+            )
+        }
     }
 
     /// Parse the webhook event from the request body and return categorized event

--- a/Tests/DocuSealKitTests/DocuSealKitTests.swift
+++ b/Tests/DocuSealKitTests/DocuSealKitTests.swift
@@ -860,3 +860,78 @@ struct ClientConfigurationTests {
         #expect(webhook.data.values?.isEmpty == true)
     }
 }
+
+// MARK: - Webhook Verification Tests
+
+@Suite("Webhook Verification Tests")
+struct WebhookVerificationTests {
+
+    @Test("Webhook secret verification succeeds with correct credentials")
+    func testWebhookSecretVerificationSuccess() throws {
+        // Should not throw any error
+        try DocusealWebhookHandler.verifyWebhookSecret(
+            receivedKey: "X-DocuSeal-Secret-Key",
+            receivedValue: "my-secret-value",
+            expectedKey: "X-DocuSeal-Secret-Key",
+            expectedValue: "my-secret-value"
+        )
+    }
+
+    @Test("Webhook secret verification fails with wrong key")
+    func testWebhookSecretVerificationFailsWrongKey() throws {
+        #expect {
+            try DocusealWebhookHandler.verifyWebhookSecret(
+                receivedKey: "Wrong-Key",
+                receivedValue: "my-secret-value",
+                expectedKey: "X-DocuSeal-Secret-Key",
+                expectedValue: "my-secret-value"
+            )
+        } throws: { error in
+            if let docuSealError = error as? DocuSealError,
+                case .webhookAuthenticationError(_) = docuSealError
+            {
+                return true
+            }
+            return false
+        }
+    }
+
+    @Test("Webhook secret verification fails with wrong value")
+    func testWebhookSecretVerificationFailsWrongValue() throws {
+        #expect {
+            try DocusealWebhookHandler.verifyWebhookSecret(
+                receivedKey: "X-DocuSeal-Secret-Key",
+                receivedValue: "wrong-value",
+                expectedKey: "X-DocuSeal-Secret-Key",
+                expectedValue: "my-secret-value"
+            )
+        } throws: { error in
+            if let docuSealError = error as? DocuSealError,
+                case .webhookAuthenticationError(_) = docuSealError
+            {
+                return true
+            }
+            return false
+        }
+    }
+
+    @Test("Webhook secret verification fails with empty credentials")
+    func testWebhookSecretVerificationFailsEmpty() throws {
+        #expect {
+            try DocusealWebhookHandler.verifyWebhookSecret(
+                receivedKey: "",
+                receivedValue: "",
+                expectedKey: "X-DocuSeal-Secret-Key",
+                expectedValue: "my-secret-value"
+            )
+        } throws: { error in
+            if let docuSealError = error as? DocuSealError,
+                case .webhookAuthenticationError(_) = docuSealError
+            {
+                return true
+            }
+            return false
+        }
+    }
+
+}


### PR DESCRIPTION
Replaces signature verification with key-value header authentication for DocuSeal webhooks. Adds DocuSealError.webhookAuthenticationError and updates documentation. Includes comprehensive tests for webhook secret verification.