### PR TITLE
Add FieldValueType for typed field values

### DIFF
--- a/Sources/DocuSealKit/Models/TemplateModels.swift
+++ b/Sources/DocuSealKit/Models/TemplateModels.swift
@@ -25,11 +25,132 @@ public struct FieldValue: Codable, Sendable {
     /// The field name.
     public let field: String
     /// The field value.
-    public let value: String
+    public let value: FieldValueType?
 
-    public init(field: String, value: String) {
+    public init(field: String, value: FieldValueType?) {
         self.field = field
         self.value = value
+    }
+
+    // MARK: - Convenience Initializers
+
+    /// Initialize with a string value
+    public init(field: String, stringValue: String) {
+        self.field = field
+        self.value = .string(stringValue)
+    }
+
+    /// Initialize with a boolean value
+    public init(field: String, boolValue: Bool) {
+        self.field = field
+        self.value = .bool(boolValue)
+    }
+
+    /// Initialize with an integer value
+    public init(field: String, intValue: Int) {
+        self.field = field
+        self.value = .int(intValue)
+    }
+
+    /// Initialize with a double value
+    public init(field: String, doubleValue: Double) {
+        self.field = field
+        self.value = .double(doubleValue)
+    }
+
+    /// Initialize with a nil value
+    public init(field: String) {
+        self.field = field
+        self.value = nil
+    }
+}
+
+public enum FieldValueType: Codable, Sendable {
+    case string(String)
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if let stringValue = try? container.decode(String.self) {
+            self = .string(stringValue)
+        } else if let boolValue = try? container.decode(Bool.self) {
+            self = .bool(boolValue)
+        } else if let intValue = try? container.decode(Int.self) {
+            self = .int(intValue)
+        } else if let doubleValue = try? container.decode(Double.self) {
+            self = .double(doubleValue)
+        } else {
+            throw DecodingError.typeMismatch(
+                FieldValueType.self,
+                DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unable to decode FieldValueType")
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .string(let value):
+            try container.encode(value)
+        case .bool(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        case .double(let value):
+            try container.encode(value)
+        }
+    }
+
+    // MARK: - Convenience Properties
+
+    /// Returns the value as a String if it's a string type
+    public var stringValue: String? {
+        if case .string(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    /// Returns the value as a Bool if it's a bool type
+    public var boolValue: Bool? {
+        if case .bool(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    /// Returns the value as an Int if it's an int type
+    public var intValue: Int? {
+        if case .int(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    /// Returns the value as a Double if it's a double type
+    public var doubleValue: Double? {
+        if case .double(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    /// Returns a string representation of the value regardless of type
+    public var description: String {
+        switch self {
+        case .string(let value):
+            return value
+        case .bool(let value):
+            return String(value)
+        case .int(let value):
+            return String(value)
+        case .double(let value):
+            return String(value)
+        }
     }
 }
 

--- a/Tests/DocuSealKitTests/BooleanFieldTests.swift
+++ b/Tests/DocuSealKitTests/BooleanFieldTests.swift
@@ -44,17 +44,17 @@ struct BooleanFieldTests {
     @Test("Field values support mixed boolean types")
     func testMixedBooleanFieldValues() async throws {
         let values = [
-            FieldValue(field: "agrees_terms", value: "true"),
-            FieldValue(field: "newsletter_signup", value: "1"),
-            FieldValue(field: "privacy_consent", value: "false"),
-            FieldValue(field: "sms_notifications", value: "0"),
+            FieldValue(field: "agrees_terms", stringValue: "true"),
+            FieldValue(field: "newsletter_signup", stringValue: "1"),
+            FieldValue(field: "privacy_consent", stringValue: "false"),
+            FieldValue(field: "sms_notifications", stringValue: "0"),
         ]
 
         #expect(values.count == 4)
-        #expect(values[0].value == "true")
-        #expect(values[1].value == "1")
-        #expect(values[2].value == "false")
-        #expect(values[3].value == "0")
+        #expect(values[0].value?.stringValue == "true")
+        #expect(values[1].value?.stringValue == "1")
+        #expect(values[2].value?.stringValue == "false")
+        #expect(values[3].value?.stringValue == "0")
     }
 
     @Test("Boolean validation patterns accept multiple formats")

--- a/Tests/DocuSealKitTests/DocuSealKitTests.swift
+++ b/Tests/DocuSealKitTests/DocuSealKitTests.swift
@@ -233,7 +233,7 @@ struct ClientConfigurationTests {
         // Validate field values
         #expect(webhook.data.values?.count == 1)
         #expect(webhook.data.values?.first?.field == "First person")
-        #expect(webhook.data.values?.first?.value.contains("signature.png") == true)
+        #expect(webhook.data.values?.first?.value?.stringValue?.contains("signature.png") == true)
 
         // Validate documents
         #expect(webhook.data.documents?.count == 1)
@@ -332,8 +332,8 @@ struct ClientConfigurationTests {
         #expect(webhook.data.values?.count == 2)
         let values = webhook.data.values ?? []
         #expect(values.allSatisfy { $0.field == "Neighbor" })
-        #expect(values.first?.value.contains("initials.png") == true)
-        #expect(values.last?.value.contains("signature.png") == true)
+        #expect(values.first?.value?.stringValue?.contains("initials.png") == true)
+        #expect(values.last?.value?.stringValue?.contains("signature.png") == true)
 
         // Validate template with subfolder
         #expect(webhook.data.template?.folderName == "ACH Health/Abstract")

--- a/Tests/DocuSealKitTests/FieldValueTests.swift
+++ b/Tests/DocuSealKitTests/FieldValueTests.swift
@@ -1,0 +1,302 @@
+//
+//  FieldValueTests.swift
+//  docuseal-kit
+//
+//  Created by Stevenson Michel on 1/3/25.
+//
+
+import Foundation
+import Testing
+
+@testable import DocuSealKit
+
+// MARK: - FieldValue Decoding Tests
+
+@Suite("FieldValue Model Tests")
+struct FieldValueTests {
+
+    // MARK: - JSON Decoding Tests
+
+    @Test("Decode boolean field value")
+    func testDecodeBooleanFieldValue() async throws {
+        let json = """
+            {
+                "field": "Check Box2",
+                "value": false
+            }
+            """
+
+        let data = json.data(using: .utf8)!
+        let fieldValue = try JSONDecoder().decode(FieldValue.self, from: data)
+
+        #expect(fieldValue.field == "Check Box2")
+        #expect(fieldValue.value?.boolValue == false)
+        #expect(fieldValue.value?.stringValue == nil)
+    }
+
+    @Test("Decode null field value")
+    func testDecodeNullFieldValue() async throws {
+        let json = """
+            {
+                "field": "Text11",
+                "value": null
+            }
+            """
+
+        let data = json.data(using: .utf8)!
+        let fieldValue = try JSONDecoder().decode(FieldValue.self, from: data)
+
+        #expect(fieldValue.field == "Text11")
+        #expect(fieldValue.value == nil)
+    }
+
+    @Test("Decode string field value")
+    func testDecodeStringFieldValue() async throws {
+        let json = """
+            {
+                "field": "First Name",
+                "value": "John Doe"
+            }
+            """
+
+        let data = json.data(using: .utf8)!
+        let fieldValue = try JSONDecoder().decode(FieldValue.self, from: data)
+
+        #expect(fieldValue.field == "First Name")
+        #expect(fieldValue.value?.stringValue == "John Doe")
+        #expect(fieldValue.value?.boolValue == nil)
+    }
+
+    @Test("Decode integer field value")
+    func testDecodeIntegerFieldValue() async throws {
+        let json = """
+            {
+                "field": "Age",
+                "value": 25
+            }
+            """
+
+        let data = json.data(using: .utf8)!
+        let fieldValue = try JSONDecoder().decode(FieldValue.self, from: data)
+
+        #expect(fieldValue.field == "Age")
+        #expect(fieldValue.value?.intValue == 25)
+        #expect(fieldValue.value?.stringValue == nil)
+    }
+
+    @Test("Decode double field value")
+    func testDecodeDoubleFieldValue() async throws {
+        let json = """
+            {
+                "field": "Salary",
+                "value": 50000.50
+            }
+            """
+
+        let data = json.data(using: .utf8)!
+        let fieldValue = try JSONDecoder().decode(FieldValue.self, from: data)
+
+        #expect(fieldValue.field == "Salary")
+        #expect(fieldValue.value?.doubleValue == 50000.50)
+        #expect(fieldValue.value?.intValue == nil)
+    }
+
+    @Test("Decode array of mixed field values")
+    func testDecodeMixedFieldValuesArray() async throws {
+        let json = """
+            [
+                {
+                    "field": "Check Box2",
+                    "value": false
+                },
+                {
+                    "field": "Check Box3",
+                    "value": true
+                },
+                {
+                    "field": "Text11",
+                    "value": null
+                },
+                {
+                    "field": "First Name",
+                    "value": "Jane Smith"
+                },
+                {
+                    "field": "Age",
+                    "value": 30
+                },
+                {
+                    "field": "Rating",
+                    "value": 4.5
+                }
+            ]
+            """
+
+        let data = json.data(using: .utf8)!
+        let fieldValues = try JSONDecoder().decode([FieldValue].self, from: data)
+
+        #expect(fieldValues.count == 6)
+
+        // Test boolean false
+        #expect(fieldValues[0].field == "Check Box2")
+        #expect(fieldValues[0].value?.boolValue == false)
+
+        // Test boolean true
+        #expect(fieldValues[1].field == "Check Box3")
+        #expect(fieldValues[1].value?.boolValue == true)
+
+        // Test null value
+        #expect(fieldValues[2].field == "Text11")
+        #expect(fieldValues[2].value == nil)
+
+        // Test string value
+        #expect(fieldValues[3].field == "First Name")
+        #expect(fieldValues[3].value?.stringValue == "Jane Smith")
+
+        // Test integer value
+        #expect(fieldValues[4].field == "Age")
+        #expect(fieldValues[4].value?.intValue == 30)
+
+        // Test double value
+        #expect(fieldValues[5].field == "Rating")
+        #expect(fieldValues[5].value?.doubleValue == 4.5)
+    }
+
+    // MARK: - JSON Encoding Tests
+
+    @Test("Encode boolean field value")
+    func testEncodeBooleanFieldValue() async throws {
+        let fieldValue = FieldValue(field: "Check Box", boolValue: true)
+
+        let data = try JSONEncoder().encode(fieldValue)
+        let json = String(data: data, encoding: .utf8)!
+
+        #expect(json.contains("\"field\":\"Check Box\""))
+        #expect(json.contains("\"value\":true"))
+    }
+
+    @Test("Encode null field value")
+    func testEncodeNullFieldValue() async throws {
+        let fieldValue = FieldValue(field: "Empty Field")
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted]
+        let data = try encoder.encode(fieldValue)
+        let json = String(data: data, encoding: .utf8)!
+
+        #expect(json.contains("\"field\" : \"Empty Field\""))
+        #expect(fieldValue.value == nil)
+    }
+
+    @Test("Encode string field value")
+    func testEncodeStringFieldValue() async throws {
+        let fieldValue = FieldValue(field: "Name", stringValue: "Test User")
+
+        let data = try JSONEncoder().encode(fieldValue)
+        let json = String(data: data, encoding: .utf8)!
+
+        #expect(json.contains("\"field\":\"Name\""))
+        #expect(json.contains("\"value\":\"Test User\""))
+    }
+
+    @Test("Encode integer field value")
+    func testEncodeIntegerFieldValue() async throws {
+        let fieldValue = FieldValue(field: "Count", intValue: 42)
+
+        let data = try JSONEncoder().encode(fieldValue)
+        let json = String(data: data, encoding: .utf8)!
+
+        #expect(json.contains("\"field\":\"Count\""))
+        #expect(json.contains("\"value\":42"))
+    }
+
+    @Test("Encode double field value")
+    func testEncodeDoubleFieldValue() async throws {
+        let fieldValue = FieldValue(field: "Price", doubleValue: 99.99)
+
+        let data = try JSONEncoder().encode(fieldValue)
+        let json = String(data: data, encoding: .utf8)!
+
+        #expect(json.contains("\"field\":\"Price\""))
+        #expect(json.contains("\"value\":99.99"))
+    }
+
+    // MARK: - Convenience Property Tests
+
+    @Test("Test FieldValueType description property")
+    func testFieldValueTypeDescription() async throws {
+        let stringValue = FieldValueType.string("Hello World")
+        let boolValue = FieldValueType.bool(true)
+        let intValue = FieldValueType.int(123)
+        let doubleValue = FieldValueType.double(45.67)
+
+        #expect(stringValue.description == "Hello World")
+        #expect(boolValue.description == "true")
+        #expect(intValue.description == "123")
+        #expect(doubleValue.description == "45.67")
+    }
+
+    @Test("Test convenience property access")
+    func testConveniencePropertyAccess() async throws {
+        let fieldValue = FieldValue(field: "Test", stringValue: "Sample Text")
+
+        #expect(fieldValue.value?.stringValue == "Sample Text")
+        #expect(fieldValue.value?.boolValue == nil)
+        #expect(fieldValue.value?.intValue == nil)
+        #expect(fieldValue.value?.doubleValue == nil)
+    }
+
+    // MARK: - Initialization Tests
+
+    @Test("Test all convenience initializers")
+    func testConvenienceInitializers() async throws {
+        let stringField = FieldValue(field: "text", stringValue: "test")
+        let boolField = FieldValue(field: "checkbox", boolValue: false)
+        let intField = FieldValue(field: "number", intValue: 100)
+        let doubleField = FieldValue(field: "decimal", doubleValue: 3.14)
+        let nullField = FieldValue(field: "empty")
+
+        #expect(stringField.value?.stringValue == "test")
+        #expect(boolField.value?.boolValue == false)
+        #expect(intField.value?.intValue == 100)
+        #expect(doubleField.value?.doubleValue == 3.14)
+        #expect(nullField.value == nil)
+    }
+
+    // MARK: - Round-trip Tests
+
+    @Test("Test encode-decode round trip for all types")
+    func testEncodeDecodeRoundTrip() async throws {
+        let originalValues = [
+            FieldValue(field: "string_field", stringValue: "Hello"),
+            FieldValue(field: "bool_field", boolValue: true),
+            FieldValue(field: "int_field", intValue: 42),
+            FieldValue(field: "double_field", doubleValue: 3.14159),
+            FieldValue(field: "null_field"),
+        ]
+
+        // Encode
+        let data = try JSONEncoder().encode(originalValues)
+
+        // Decode
+        let decodedValues = try JSONDecoder().decode([FieldValue].self, from: data)
+
+        // Verify
+        #expect(decodedValues.count == originalValues.count)
+
+        #expect(decodedValues[0].field == "string_field")
+        #expect(decodedValues[0].value?.stringValue == "Hello")
+
+        #expect(decodedValues[1].field == "bool_field")
+        #expect(decodedValues[1].value?.boolValue == true)
+
+        #expect(decodedValues[2].field == "int_field")
+        #expect(decodedValues[2].value?.intValue == 42)
+
+        #expect(decodedValues[3].field == "double_field")
+        #expect(decodedValues[3].value?.doubleValue == 3.14159)
+
+        #expect(decodedValues[4].field == "null_field")
+        #expect(decodedValues[4].value == nil)
+    }
+}


### PR DESCRIPTION
Introduces FieldValueType enum to support string, bool, int, and double types for FieldValue.value, replacing the previous String-only value. Adds convenience initializers and accessors to FieldValue, updates tests to use the new API, and adds comprehensive FieldValueTests for encoding, decoding, and property access.