### PR TITLE
Refactor webhook secret verification and update SDK version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the following to your `Package.swift` file's dependencies:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/thoven87/docuseal-kit.git", from: "1.0.0")
+    .package(url: "https://github.com/thoven87/docuseal-kit.git", from: "2.0.0")
 ]
 ```
 
@@ -231,10 +231,8 @@ DocuSeal uses key-value pairs in request headers for webhook authentication. Con
 ```swift
 // Verify webhook authenticity - throws DocuSealError.webhookAuthenticationError if invalid
 try DocusealWebhookHandler.verifyWebhookSecret(
-    receivedKey: request.headers["X-Secret-Key"]?.first ?? "",
-    receivedValue: request.headers["X-Secret-Value"]?.first ?? "",
-    expectedKey: "your-secret-key",
-    expectedValue: "your-secret-value"
+    receivedKey: request.headers["X-Secret-Value"]?.first ?? "",
+    expectedKey: "your-secret-value"
 )
 ```
 

--- a/Sources/DocuSealKit/DocuSealWebhooks.swift
+++ b/Sources/DocuSealKit/DocuSealWebhooks.swift
@@ -530,14 +530,12 @@ public struct DocusealWebhookHandler {
     /// Throws DocuSealError.webhookAuthenticationError if verification fails
     public static func verifyWebhookSecret(
         receivedKey: String,
-        receivedValue: String,
-        expectedKey: String,
-        expectedValue: String
+        expectedKey: String
     ) throws {
-        guard receivedKey == expectedKey && receivedValue == expectedValue else {
+        guard receivedKey == expectedKey else {
             throw DocuSealError.webhookAuthenticationError(
                 message:
-                    "Invalid webhook credentials - received key '\(receivedKey)' with value '\(receivedValue)' does not match expected credentials"
+                    "Invalid webhook credentials - received key '\(receivedKey)' with value '\(expectedKey)' does not match expected credentials"
             )
         }
     }

--- a/Tests/DocuSealKitTests/DocuSealKitTests.swift
+++ b/Tests/DocuSealKitTests/DocuSealKitTests.swift
@@ -871,9 +871,7 @@ struct WebhookVerificationTests {
         // Should not throw any error
         try DocusealWebhookHandler.verifyWebhookSecret(
             receivedKey: "X-DocuSeal-Secret-Key",
-            receivedValue: "my-secret-value",
-            expectedKey: "X-DocuSeal-Secret-Key",
-            expectedValue: "my-secret-value"
+            expectedKey: "X-DocuSeal-Secret-Key"
         )
     }
 
@@ -882,9 +880,7 @@ struct WebhookVerificationTests {
         #expect {
             try DocusealWebhookHandler.verifyWebhookSecret(
                 receivedKey: "Wrong-Key",
-                receivedValue: "my-secret-value",
-                expectedKey: "X-DocuSeal-Secret-Key",
-                expectedValue: "my-secret-value"
+                expectedKey: "X-DocuSeal-Secret-Key"
             )
         } throws: { error in
             if let docuSealError = error as? DocuSealError,
@@ -901,9 +897,7 @@ struct WebhookVerificationTests {
         #expect {
             try DocusealWebhookHandler.verifyWebhookSecret(
                 receivedKey: "X-DocuSeal-Secret-Key",
-                receivedValue: "wrong-value",
-                expectedKey: "X-DocuSeal-Secret-Key",
-                expectedValue: "my-secret-value"
+                expectedKey: "X-DocuSeal-Secret"
             )
         } throws: { error in
             if let docuSealError = error as? DocuSealError,
@@ -920,9 +914,7 @@ struct WebhookVerificationTests {
         #expect {
             try DocusealWebhookHandler.verifyWebhookSecret(
                 receivedKey: "",
-                receivedValue: "",
-                expectedKey: "X-DocuSeal-Secret-Key",
-                expectedValue: "my-secret-value"
+                expectedKey: "X-DocuSeal-Secret-Key"
             )
         } throws: { error in
             if let docuSealError = error as? DocuSealError,


### PR DESCRIPTION
Simplified DocusealWebhookHandler.verifyWebhookSecret to only require a single key for verification, removing the value parameter. Updated related documentation and tests to reflect this change. Also updated the user agent string and default content length handling in DocuSealClient, and bumped the SDK version in the README.