### PR TITLE
Add Sendable conformance to models and enums

### DIFF
--- a/Sources/DocuSealKit/DocuSealWebhooks.swift
+++ b/Sources/DocuSealKit/DocuSealWebhooks.swift
@@ -9,7 +9,7 @@ import Foundation
 import NIOCore
 import NIOFoundationCompat
 
-public enum DocuSealSubmissionWebhookEventType: String, Codable {
+public enum DocuSealSubmissionWebhookEventType: String, Codable, Sendable {
     // Submission Webhooks
     case submissionCreated = "submission.created"
     case submissionArchived = "submission.archived"
@@ -17,7 +17,7 @@ public enum DocuSealSubmissionWebhookEventType: String, Codable {
     case submissionExpired = "submission.expired"
 }
 
-public enum DocuSealFormWebhookEventType: String, Codable {
+public enum DocuSealFormWebhookEventType: String, Codable, Sendable {
     // Form Webhooks
     case formViewed = "form.viewed"
     case formStarted = "form.started"
@@ -25,7 +25,7 @@ public enum DocuSealFormWebhookEventType: String, Codable {
     case formDeclined = "form.declined"
 }
 
-public enum DocuSealTemplateWebhookEventType: String, Codable {
+public enum DocuSealTemplateWebhookEventType: String, Codable, Sendable {
     // Template Webhooks
     case templateCreated = "template.created"
     case templateUpdated = "template.updated"
@@ -41,7 +41,7 @@ public enum DocuSealWebhookEventCategory {
 
 // MARK: - Base Webhook Event
 
-public struct DocuSealWebhookEvent<T: Codable, E: Codable>: Codable {
+public struct DocuSealWebhookEvent<T: Codable & Sendable, E: Codable & Sendable>: Codable {
     /// The event type.
     public let eventType: E
     /// The event timestamp.
@@ -65,7 +65,7 @@ public struct DocuSealWebhookEvent<T: Codable, E: Codable>: Codable {
 
 // MARK: - Form Webhook Data
 
-public struct DocuSealFormWebhookData: Codable {
+public struct DocuSealFormWebhookData: Codable, Sendable {
     /// The submitter's unique identifier.
     public let id: Int
     /// The unique submission identifier.
@@ -117,7 +117,7 @@ public struct DocuSealFormWebhookData: Codable {
     /// Documents
     public let documents: [Document]?
 
-    public struct Preferences: Codable {
+    public struct Preferences: Codable, Sendable {
         /// The flag indicating whether the submitter has opted to receive an email.
         public let sendEmail: Bool
         /// The flag indicating whether the submitter has opted to receive an SMS.
@@ -212,7 +212,7 @@ public struct DocuSealFormWebhookData: Codable {
     }
 }
 
-public struct DocuSealFormSubmissionInfo: Codable {
+public struct DocuSealFormSubmissionInfo: Codable, Sendable {
     /// The submission's unique identifier.
     public let id: Int
     /// The audit log PDF URL. Available only if the submission was completed by all submitters.
@@ -259,7 +259,7 @@ public struct DocuSealFormSubmissionInfo: Codable {
 //'submission.completed' event is triggered when the submission is completed by all signing parties.
 //'submission.expired' event is triggered when the submission expires.
 //'submission.archived' event is triggered when the submission is archived.
-public struct DocuSealSubmissionWebhookData: Codable {
+public struct DocuSealSubmissionWebhookData: Codable, Sendable {
     /// The submission's unique identifier.
     public let id: Int
     /// The submission archive date.
@@ -292,7 +292,7 @@ public struct DocuSealSubmissionWebhookData: Codable {
     /// The date and time when the submission was fully completed.
     public let completedAt: Date?
 
-    public enum Source: String, Codable {
+    public enum Source: String, Codable, Sendable {
         case invite = "invite"
         case bulk = "bulk"
         case api = "api"
@@ -350,7 +350,7 @@ public struct DocuSealSubmissionWebhookData: Codable {
     }
 }
 
-public struct DocuSealWebhookSubmissionEvent: Codable {
+public struct DocuSealWebhookSubmissionEvent: Codable, Sendable {
     /// Submission event unique ID number.
     public let id: Int
     /// Unique identifier of the submitter that triggered the event.
@@ -360,7 +360,7 @@ public struct DocuSealWebhookSubmissionEvent: Codable {
     /// Date and time when the event was triggered.
     public let eventTimestamp: Date
 
-    public enum EventType: String, Codable {
+    public enum EventType: String, Codable, Sendable {
         case sendEmail = "send_email"
         case bounceEmail = "bounce_email"
         case complaintEmail = "complaint_email"
@@ -400,7 +400,7 @@ public struct DocuSealWebhookSubmissionEvent: Codable {
 /// Get template creation and update notifications using these events:
 /// 'template.created' is triggered when the template is created.
 /// 'tempate.updated' is triggered when the template is updated.
-public struct DocuSealTemplateWebhookData: Codable {
+public struct DocuSealTemplateWebhookData: Codable, Sendable {
     /// The template's unique identifier.
     public let id: Int
     /// The template's unique slug.
@@ -441,7 +441,7 @@ public struct DocuSealTemplateWebhookData: Codable {
     public let documents: [TemplateDocument]
 
     /// native, api, embed
-    public enum Source: String, Codable {
+    public enum Source: String, Codable, Sendable {
         case api
         case embed
         case native

--- a/Sources/DocuSealKit/Models/SubmissionModels.swift
+++ b/Sources/DocuSealKit/Models/SubmissionModels.swift
@@ -20,7 +20,7 @@ public enum DocuSealSubmissionStatus: String, Codable, Sendable {
 
 // MARK: - Submission Models
 
-public struct Submission: Codable {
+public struct Submission: Codable, Sendable {
     public let id: Int
     public let source: String
     public let submittersOrder: SubmittersOrder
@@ -98,7 +98,7 @@ public struct Submission: Codable {
     }
 }
 
-public struct SubmissionDocuments: Codable {
+public struct SubmissionDocuments: Codable, Sendable {
     public let id: Int
     public let documents: [Document]
 
@@ -110,7 +110,7 @@ public struct SubmissionDocuments: Codable {
 
 // MARK: - Submission List Response
 
-public struct SubmissionListResponse: Codable {
+public struct SubmissionListResponse: Codable, Sendable {
     public let data: [Submission]
     public let pagination: Pagination
 
@@ -122,7 +122,7 @@ public struct SubmissionListResponse: Codable {
 
 // MARK: - Submission List Query
 
-public struct SubmissionListQuery: Codable {
+public struct SubmissionListQuery: Codable, Sendable {
     /// The template ID allows you to receive only the submissions created from that specific template.
     public let templateId: Int?
     /// Filter submissions by status.
@@ -203,12 +203,12 @@ public struct SubmissionListQuery: Codable {
 
 // MARK: - Create Submission Request
 
-public enum SubmittersOrder: String, Codable {
+public enum SubmittersOrder: String, Codable, Sendable {
     case random = "random"
     case preserved = "preserved"
 }
 
-public struct CreateSubmissionRequest: Codable {
+public struct CreateSubmissionRequest: Codable, Sendable {
     /// The unique identifier of the template. Document template forms can be created via the Web UI, PDF and DOCX API, or HTML API.
     /// Example: 1000001
     public let templateId: Int
@@ -274,7 +274,7 @@ public struct CreateSubmissionRequest: Codable {
     }
 }
 
-public struct SubmissionMessage: Codable {
+public struct SubmissionMessage: Codable, Sendable {
     /// Custom signature request email subject.
     public let subject: String?
     /// Custom signature request email body. Can include the following variables: {{template.name}}, {{submitter.link}}, {{account.name}}.
@@ -286,7 +286,7 @@ public struct SubmissionMessage: Codable {
     }
 }
 
-public struct SubmissionSubmitter: Codable {
+public struct SubmissionSubmitter: Codable, Sendable {
     /// The name of the submitter.
     public let name: String?
     /// The role name or title of the submitter.
@@ -442,7 +442,7 @@ public struct SubmissionField: Codable, Sendable {
 
 // MARK: - Create Submissions From Emails Request
 
-public struct CreateSubmissionsFromEmailsRequest: Codable {
+public struct CreateSubmissionsFromEmailsRequest: Codable, Sendable {
     /// The unique identifier of the template.
     /// Example: 1000001
     public let templateId: Int
@@ -476,7 +476,7 @@ public struct CreateSubmissionsFromEmailsRequest: Codable {
 }
 
 // MARK: - Create Submission From PDF Request
-public struct CreateSubmissionFromPdfRequest: Codable {
+public struct CreateSubmissionFromPdfRequest: Codable, Sendable {
     /// Base64 encoded PDF file or public URL
     public let pdf: String
 
@@ -564,7 +564,7 @@ public struct CreateSubmissionFromPdfRequest: Codable {
 }
 
 // MARK: - Create Submission From HTML Request
-public struct CreateSubmissionFromHtmlRequest: Codable {
+public struct CreateSubmissionFromHtmlRequest: Codable, Sendable {
     /// HTML content
     public let html: String
 
@@ -646,7 +646,7 @@ public struct CreateSubmissionFromHtmlRequest: Codable {
 }
 
 // MARK: - Create Submission From DOCX Request
-public struct CreateSubmissionFromDocxRequest: Codable {
+public struct CreateSubmissionFromDocxRequest: Codable, Sendable {
     /// Base64 encoded DOCX file or public URL
     public let docx: String
 
@@ -734,7 +734,7 @@ public struct CreateSubmissionFromDocxRequest: Codable {
 }
 
 // MARK: - Enhanced Create Submission Response
-public struct CreateSubmissionResponse: Codable {
+public struct CreateSubmissionResponse: Codable, Sendable {
     /// Unique identifier of the submission
     public let id: Int
 
@@ -791,7 +791,7 @@ public struct FieldValidation: Codable, Sendable {
 }
 
 // MARK: - Query Parameters with Include Support
-public struct SubmissionQuery: Codable {
+public struct SubmissionQuery: Codable, Sendable {
     /// Include additional related data
     public let include: String?
 
@@ -810,7 +810,7 @@ public struct SubmissionQuery: Codable {
     }
 }
 
-public struct SubmissionDocumentsQuery: Codable {
+public struct SubmissionDocumentsQuery: Codable, Sendable {
     /// Include additional related data
     public let include: String?
 

--- a/Sources/DocuSealKit/Models/SubmitterModels.swift
+++ b/Sources/DocuSealKit/Models/SubmitterModels.swift
@@ -179,7 +179,7 @@ public struct Submitter: Codable, Sendable {
 
 // MARK: - Submitter List Response
 
-public struct SubmitterListResponse: Codable {
+public struct SubmitterListResponse: Codable, Sendable {
     public let data: [Submitter]
     public let pagination: Pagination
 
@@ -190,7 +190,7 @@ public struct SubmitterListResponse: Codable {
 }
 
 // MARK: - Submitter Query with Include Support
-public struct SubmitterQuery: Codable {
+public struct SubmitterQuery: Codable, Sendable {
     /// Include additional related data
     public let include: String?
 
@@ -211,7 +211,7 @@ public struct SubmitterQuery: Codable {
 
 // MARK: - Submitter List Query
 
-public struct SubmitterListQuery: Codable {
+public struct SubmitterListQuery: Codable, Sendable {
     /// The submission ID allows you to receive only the submitters related to that specific submission.
     public let submissionId: Int?
     /// Filter submitters on name, email or phone partial match.
@@ -296,7 +296,7 @@ public struct SubmitterListQuery: Codable {
 
 // MARK: - Update Submitter Request
 
-public struct UpdateSubmitterRequest: Codable {
+public struct UpdateSubmitterRequest: Codable, Sendable {
     /// The name of the submitter.
     public let name: String?
     /// The email address of the submitter.

--- a/Sources/DocuSealKit/Models/TemplateModels+Requests.swift
+++ b/Sources/DocuSealKit/Models/TemplateModels+Requests.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // MARK: - Create Template from Word DOCX
 
-public struct CreateTemplateFromDocxRequest: Codable {
+public struct CreateTemplateFromDocxRequest: Codable, Sendable {
     /// Name of the template
     /// Example: Test DOCX
     public let name: String?
@@ -46,7 +46,7 @@ public struct CreateTemplateFromDocxRequest: Codable {
     }
 }
 
-public struct TemplateDocumentRequest: Codable {
+public struct TemplateDocumentRequest: Codable, Sendable {
     /// Name of the document.
     public let name: String
     /// Base64-encoded content of the DOCX file or downloadable file URL
@@ -66,7 +66,7 @@ public struct TemplateDocumentRequest: Codable {
     }
 }
 
-public enum TemplateFieldType: String, Codable {
+public enum TemplateFieldType: String, Codable, Sendable {
     case heading = "heading"
     case text = "text"
     case signature = "signature"
@@ -86,7 +86,7 @@ public enum TemplateFieldType: String, Codable {
     case verification = "verification"
 }
 
-public struct TemplateFieldRequest: Codable {
+public struct TemplateFieldRequest: Codable, Sendable {
     /// Name of the field.
     public let name: String
     /// Type of the field (e.g., text, signature, date, initials).
@@ -131,7 +131,7 @@ public struct TemplateFieldRequest: Codable {
     }
 }
 
-public struct TemplateFieldAreaRequest: Codable {
+public struct TemplateFieldAreaRequest: Codable, Sendable {
     /// X-coordinate of the field area.
     public let x: Double
     /// Y-coordinate of the field area.
@@ -164,7 +164,7 @@ public struct TemplateFieldAreaRequest: Codable {
 
 // MARK: - Create Template from HTML
 
-public enum DocuSealPageSize: String, Codable {
+public enum DocuSealPageSize: String, Codable, Sendable {
     case letter = "Letter"
     case a0 = "A0"
     case a1 = "A1"
@@ -179,7 +179,7 @@ public enum DocuSealPageSize: String, Codable {
     case ledge = "Ledger"
 }
 
-public struct CreateTemplateFromHtmlRequest: Codable {
+public struct CreateTemplateFromHtmlRequest: Codable, Sendable {
     /// HTML template with field tags.
     ///    Example: <p>Lorem Ipsum is simply dummy text of the <text-field name="Industry" role="First Party" required="false" style="width: 80px; height: 16px; display: inline-block; margin-bottom: -4px"> </text-field> and typesetting industry</p>
     public let html: String
@@ -240,7 +240,7 @@ public struct CreateTemplateFromHtmlRequest: Codable {
     }
 }
 
-public struct HtmlDocumentRequest: Codable {
+public struct HtmlDocumentRequest: Codable, Sendable {
     /// HTML template with field tags.
     /// Example: <p>Lorem Ipsum is simply dummy text of the <text-field name="Industry" role="First Party" required="false" style="width: 80px; height: 16px; display: inline-block; margin-bottom: -4px"> </text-field> and typesetting industry</p>
     public let html: String
@@ -256,7 +256,7 @@ public struct HtmlDocumentRequest: Codable {
 
 // MARK: - Create Template from PDF
 
-public struct CreateTemplateFromPdfRequest: Codable {
+public struct CreateTemplateFromPdfRequest: Codable, Sendable {
     /// Name of the template
     /// Example: Test PDF
     public let name: String?
@@ -310,7 +310,7 @@ public struct CreateTemplateFromPdfRequest: Codable {
 
 // MARK: - Merge Templates
 
-public struct MergeTemplatesRequest: Codable {
+public struct MergeTemplatesRequest: Codable, Sendable {
     /// An array of template ids to merge into a new template.
     /// Example: [321,432]
     public let templateIds: [Int]
@@ -350,7 +350,7 @@ public struct MergeTemplatesRequest: Codable {
 
 // MARK: - Update Template
 
-public struct UpdateTemplateRequest: Codable {
+public struct UpdateTemplateRequest: Codable, Sendable {
     /// The name of the template
     /// Example: New Document Name
     public let name: String?
@@ -385,7 +385,7 @@ public struct UpdateTemplateRequest: Codable {
 
 // MARK: - Update Template Documents
 
-public struct UpdateTemplateDocumentsRequest: Codable {
+public struct UpdateTemplateDocumentsRequest: Codable, Sendable {
     /// The list of documents to add or replace in the template.
     public let documents: [UpdateTemplateDocumentRequest]
     /// Set to `true` to merge all existing and new documents into a single PDF document in the template.
@@ -401,7 +401,7 @@ public struct UpdateTemplateDocumentsRequest: Codable {
     }
 }
 
-public struct UpdateTemplateDocumentRequest: Codable {
+public struct UpdateTemplateDocumentRequest: Codable, Sendable {
     /// Document name. Random uuid will be assigned when not specified.
     /// Example: Test Template
     public let name: String?

--- a/Sources/DocuSealKit/Models/TemplateModels.swift
+++ b/Sources/DocuSealKit/Models/TemplateModels.swift
@@ -565,7 +565,7 @@ public struct TemplateListQuery: Codable, Sendable {
 }
 
 // MARK: - Template Query with Include Support
-public struct TemplateQuery: Codable {
+public struct TemplateQuery: Codable, Sendable {
     /// Include additional related data
     public let include: String?
 


### PR DESCRIPTION
This commit adds the Sendable protocol conformance to various model structs and enums throughout the DocuSealKit codebase. This improves concurrency safety and enables usage of these types in Swift's structured concurrency contexts.