### PR TITLE
Fix decoding and make archivedAt optional

### DIFF
--- a/Sources/DocuSealKit/DocuSealClient.swift
+++ b/Sources/DocuSealKit/DocuSealClient.swift
@@ -115,7 +115,7 @@ public struct DocuSealClient: Sendable {
 
         do {
             let body = try await response.body.collect(upTo: expectedBytes)  // 5MB max
-            return try JSONDecoder.docuSealDecoder.decode(T.self, from: Data(body.readableBytesView))
+            return try JSONDecoder.docuSealDecoder.decode(T.self, from: body)
         } catch {
             logger.error("Failed to decode response: \(error)")
             throw DocuSealError.decodingError(message: String(describing: error))

--- a/Sources/DocuSealKit/Models/TemplateModels.swift
+++ b/Sources/DocuSealKit/Models/TemplateModels.swift
@@ -254,9 +254,9 @@ public struct EventRecord: Codable, Sendable {
 
 public struct ArchiveResponse: Codable, Sendable {
     public let id: Int
-    public let archivedAt: Date
+    public let archivedAt: Date?
 
-    public init(id: Int, archivedAt: Date) {
+    public init(id: Int, archivedAt: Date?) {
         self.id = id
         self.archivedAt = archivedAt
     }


### PR DESCRIPTION
Updated DocuSealClient to decode directly from the response body instead of converting to Data. Changed ArchiveResponse.archivedAt to be optional to handle cases where the archive date may be missing.